### PR TITLE
Expand options in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/IanVS/nutshell-api-client.svg?branch=add-travis)](https://travis-ci.org/IanVS/nutshell-api-client)
 [![Dependency Status](https://www.versioneye.com/user/projects/5609a30e5a262f001a00022a/badge.svg?style=flat)](https://www.versioneye.com/user/projects/5609a30e5a262f001a00022a)
 
-Example [Nutshell](https://www.nutshell.com/) API client written in Node.js.  The only functionality this currently has is to pull the names of the top 100 (alphabetical) contacts who have email addresses.
+Example [Nutshell](https://www.nutshell.com/) API client written in Node.js.
 
 ## Installation
 
@@ -21,4 +21,12 @@ To use the cli:
 nutshell
 ```
 
-The cli will ask for a username and password, defaulting to the demo account from Nutshell's docs.  It will then query the Nutshell API for contacts, filter out the ones who don't have email addresses, and then print out the names of the top 100 alphabetically.
+The cli will ask for a user name and password, defaulting to the demo account from Nutshell's docs.  
+
+It will also ask you for:
+* The kind of objects you want to find
+* The quantity of results you want
+* Whether and how you want the results ordered
+* Whether you want to only get results which have a specified property, and if so what property that is
+
+It will then query the Nutshell API and print out the results.

--- a/index.js
+++ b/index.js
@@ -10,22 +10,33 @@ const api = require('./lib/api-client');
 // Public Interface
 //------------------------------------------------------------------------------
 
-exports.getFirstHundredContactsWithEmails = function (options, cb) {
-  options.method = 'POST';
-  options.path = '/api/v1/json';
+exports.find = function (entity, args, cb) {
+  let options = {
+    method   : 'POST',
+    path     : '/api/v1/json',
+    username : args.username,
+    password : args.password
+  };
 
   api.newNutshell(options, function (err, nutshell) {
     if (err) {
       console.error(err);
       return;
     }
-    let args = {
-      entity  : 'Contacts',
-      qty     : 100,
-      filter  : 'email',
-      orderBy : 'displayName'
-    };
-    nutshell.find(args, function (err, results) {
+    let findArgs = { entity };
+    if (args.qty) {
+      findArgs.qty = args.qty;
+    }
+    if (args.orderBy) {
+      findArgs.orderBy = args.orderBy;
+    }
+    if (args.orderDirection) {
+      findArgs.orderDirection = args.orderDirection;
+    }
+    if (args.filter) {
+      findArgs.filter = args.filter;
+    }
+    nutshell.find(findArgs, function (err, results) {
       if (err) {
         console.error(err);
         return;

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -17,16 +17,38 @@ function processAnswers(answers) {
     username : answers.username,
     password : answers.password
   };
-  index.getFirstHundredContactsWithEmails(opts, function (err, contacts) {
+  if (answers.qty) {
+    opts.qty = parseInt(answers.qty, 10);
+  }
+  if (answers.orderBy) {
+    opts.orderBy = answers.orderBy;
+  }
+  if (answers.orderDirection) {
+    opts.orderDirection = answers.orderDirection;
+  }
+  if (answers.filterProp) {
+    opts.filter = answers.filterProp;
+  }
+  index.find(answers.find, opts, function (err, results) {
     if (err) {
       console.error(err);
       return;
     }
-    let contactNamesAndEmails = contacts.map(function (contact) {
-      return `${contact.name.displayName} <${contact.email['--primary']}>`;
-    });
-    console.log(contactNamesAndEmails);
-    console.log(`Retrieved ${contacts.length} contacts with emails in ${(Date.now() - start) / 1000} seconds`);
+    let printout;
+    if (answers.find === 'Contacts') {
+      printout = results.map(function (result) {
+        if (answers.findProp === 'email') {
+          return `${result.name.displayName} <${result.email['--primary']}>`;
+        } else {
+          return result.name.displayName;
+        }
+      });
+    } else {
+      printout = results;
+    }
+
+    console.log(printout);
+    console.log(`Retrieved ${results.length} results in ${(Date.now() - start) / 1000} seconds`);
   });
 }
 
@@ -44,10 +66,84 @@ function promptUser() {
     {
       name    : 'password',
       message : 'What is your password (API Key)?',
+      type    : 'password',
       default : '43c789d483fd76547b1f157e3cf5e580b95b9d8c'
+    },
+    {
+      name    : 'find',
+      message : 'What would you like to find?',
+      type    : 'list',
+      default : 'Contacts',
+      choices : [
+        'Accounts',
+        'AccountTypes',
+        'Activities',
+        'ActivityTypes',
+        'Competitors',
+        'Contacts',
+        'Delays',
+        'Industries',
+        'Lead_Outcomes',
+        'Leads',
+        'Markes',
+        'Milestones',
+        'Origins',
+        'Products',
+        'Settings',
+        'Sources',
+        'Teams',
+        'Territories',
+        'Timeline',
+        'Users'
+      ]
+    },
+    {
+      name    : 'qty',
+      message : 'How many would you like?',
+      default : 50
+    },
+    {
+      name    : 'order',
+      message : 'Would you like the results ordered a particular way?',
+      type    : 'confirm',
+      default : false
+    },
+    {
+      name    : 'orderBy',
+      message : 'What would you like to order by?',
+      default : null,
+      when    : function (answers) {
+        return answers.order;
+      }
+    },
+    {
+      name    : 'orderDirection',
+      message : 'What should be the order direction?',
+      type    : 'list',
+      default : 'ASC',
+      choices : [
+        'ASC',
+        'DESC'
+      ],
+      when : function (answers) {
+        return answers.order;
+      }
+    },
+    {
+      name    : 'filter',
+      message : 'Would you only like results containing a particular property?',
+      type    : 'confirm',
+      default : false
+    },
+    {
+      name    : 'filterProp',
+      message : 'What property do you want to filter on?',
+      when    : function (answers) {
+        return answers.filter;
+      }
     }
   ], function (answers) {
-    console.log('Collecting first 100 contacts with email addresses. This may take a few seconds...');
+    console.log('Collecting results. This may take a few seconds...');
     processAnswers(answers);
   });
 }


### PR DESCRIPTION
Fixes #7 

It is now possible to run various `findXxxx`-style calls against the Nutshell API.
The user is presented a series of questions after running `nutshell`, such as
the things they want to find, the number they want, any requirements on order, and
properties on which to filter.

Still to do:
- Add tests :(
- Clean up/improve output
- Probably more
