### PR TITLE
Added query to nutshell api call

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,6 @@ exports.find = function (entity, args, cb) {
       findArgs.query = args.query;
     }
     nutshell.find(findArgs, function (err, results) {
-    nutshell.find(findArgs, function (err, results) {
       if (err) {
         console.error(err);
         return;

--- a/index.js
+++ b/index.js
@@ -36,6 +36,10 @@ exports.find = function (entity, args, cb) {
     if (args.filter) {
       findArgs.filter = args.filter;
     }
+    if (args.query) {
+      findArgs.query = args.query;
+    }
+    nutshell.find(findArgs, function (err, results) {
     nutshell.find(findArgs, function (err, results) {
       if (err) {
         console.error(err);


### PR DESCRIPTION
Some calls (e.g. getActivity) are not able to be used without adding parameters to the query object.
