### PR TITLE
Added error message if there was no result on the data object

### DIFF
--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -116,6 +116,10 @@ exports.newNutshell = function (opt, callback) {
             } else {
               Array.prototype.push.apply(args.state.results, data.result);
             }
+
+            if (!data.result) {
+              return cb("no result from nutshell");
+            }
             // Check if last page was received
             if (data.result.length < args.state.payload.params.limit) {
               cb(null, args.state.results);

--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -118,7 +118,7 @@ exports.newNutshell = function (opt, callback) {
             }
 
             if (!data.result) {
-              return cb("no result from nutshell");
+              return cb(new Error('No result from nutshell'));
             }
             // Check if last page was received
             if (data.result.length < args.state.payload.params.limit) {


### PR DESCRIPTION
Rather than throwing a TypeError when trying to access length on the data object (previously line 120), now it will correctly respond with a callback error.
