### PR TITLE
Updated client call to return the api error when calls fail

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ exports.find = function (entity, args, cb) {
     nutshell.find(findArgs, function (err, results) {
       if (err) {
         console.error(err);
-        return;
+        return cb(err);
       }
       cb(null, results);
     });


### PR DESCRIPTION
When this doesn't return the callback I never receive the notification that my call failed.
